### PR TITLE
Auto-detect and use GCE mirrors for apt

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Version 1.11"
 
 # Set mirrors to automatic based off location
+RUN apt-get install -y curl
 ADD files/auto-sources.sh /var/tmp/auto-sources.sh
 RUN bash /var/tmp/auto-sources.sh && rm /var/tmp/auto-sources.sh
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -7,8 +7,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Version 1.11"
 
 # Set mirrors to automatic based off location
-ADD files/auto-sources.sh /etc/apt/auto-sources.sh
-RUN bash /etc/apt/auto-sources
+ADD files/auto-sources.sh /var/tmp/auto-sources.sh
+RUN bash /var/tmp/auto-sources.sh && rm /var/tmp/auto-sources.sh
 
 RUN apt-get update --fix-missing && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:git-core/ppa

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -6,10 +6,9 @@ ENV DEBIAN_FRONTEND noninteractive
 # increment version to force flushing the cache
 RUN echo "Version 1.11"
 
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse" > /etc/apt/sources.list \
-    echo "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse" >> /etc/apt/sources.list \
-    echo "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-backports main restricted universe multiverse" >> /etc/apt/sources.list \
-    echo "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse" >> /etc/apt/sources.list
+# Set mirrors to automatic based off location
+ADD files/auto-sources.sh /etc/apt/auto-sources.sh
+RUN bash /etc/apt/auto-sources
 
 RUN apt-get update --fix-missing && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:git-core/ppa

--- a/workspace/files/auto-sources.sh
+++ b/workspace/files/auto-sources.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+DEFAULT="deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-backports main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse"
+
+GCE="deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty main restricted
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty main restricted
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty universe
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty universe
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates universe
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates universe
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty multiverse
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty multiverse
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates multiverse
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-updates multiverse
+deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-backports main restricted universe multiverse
+deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty-backports main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu trusty-security main
+deb-src http://security.ubuntu.com/ubuntu trusty-security main
+deb http://security.ubuntu.com/ubuntu trusty-security universe
+deb-src http://security.ubuntu.com/ubuntu trusty-security universe"
+
+if curl -Ss metadata &>/dev/null; then
+	REGION=$(curl -Ss -H "Metadata-Flavor: Google" metadata/computeMetadata/v1/instance/zone | sed -r 's#.*zones/((europe|us|asia)-[a-z0-9]*).*#\1#')
+	echo "${GCE//REPLACE/$REGION}" > /etc/apt/sources.list
+else
+	echo "$DEFAULT" > /etc/apt/sources.list
+fi

--- a/workspace/files/auto-sources.sh
+++ b/workspace/files/auto-sources.sh
@@ -24,9 +24,20 @@ deb-src http://security.ubuntu.com/ubuntu trusty-security main
 deb http://security.ubuntu.com/ubuntu trusty-security universe
 deb-src http://security.ubuntu.com/ubuntu trusty-security universe"
 
+[[ $1 == -o ]] && stdout=true
+
 if curl -Ss metadata &>/dev/null; then
 	REGION=$(curl -Ss -H "Metadata-Flavor: Google" metadata/computeMetadata/v1/instance/zone | sed -r 's#.*zones/((europe|us|asia)-[a-z0-9]*).*#\1#')
-	echo "${GCE//REPLACE/$REGION}" > /etc/apt/sources.list
+
+	if [[ $stdout ]]; then
+		echo "${GCE//REPLACE/$REGION}"
+	else
+		echo "${GCE//REPLACE/$REGION}" > /etc/apt/sources.list
+	fi
 else
-	echo "$DEFAULT" > /etc/apt/sources.list
+	if [[ $stdout ]]; then
+		echo "$DEFAULT"
+	else
+		echo "$DEFAULT" > /etc/apt/sources.list
+	fi
 fi

--- a/workspace/files/auto-sources.sh
+++ b/workspace/files/auto-sources.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-DEFAULT="deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-backports main restricted universe multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse"
+DEFAULT="deb http://archive.ubuntu.com/ubuntu/ trusty main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted
+deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+deb http://archive.ubuntu.com/ubuntu/ trusty universe
+deb-src http://archive.ubuntu.com/ubuntu/ trusty universe
+deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-updates universe
+deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-security main restricted
+deb http://archive.ubuntu.com/ubuntu/ trusty-security universe
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-security universe"
 
 GCE="deb http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty main restricted
 deb-src http://REPLACE.gce.clouds.archive.ubuntu.com/ubuntu/ trusty main restricted


### PR DESCRIPTION
@fjakobs @abailiss @lennartcl @timjrobinson

Only used during build phase as per https://github.com/c9/newclient/pull/12332