### PR TITLE
Go 1.6

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -201,7 +201,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
     apt-get install -y mongodb-org
 
 # /opt packages
-RUN curl https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz | tar -C /opt -xz
+RUN curl https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz | tar -C /opt -xz
 RUN git clone https://github.com/lennartcl/gitl.git /opt/gitl
 
 # Haskell


### PR DESCRIPTION
Go 1.6 has been released last wednesday (Feb 17).

- https://golang.org/doc/devel/release.html
- https://golang.org/doc/go1.6