### PR TITLE
Allow ubuntu user to create postgres databases by default

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -80,13 +80,13 @@ RUN apt-get install -y xvfb tightvncserver x11vnc novnc xterm fluxbox
 RUN apt-get install -y firefox chromium-browser
 
 # servers
-RUN apt-get install -y redis-server redis-tools nginx
-RUN apt-get install -y mysql-server rabbitmq-server couchdb
+RUN apt-get install -y redis-server redis-tools nginx mysql-server \
+    rabbitmq-server couchdb
 
 # Postgres
-RUN apt-get install -y postgresql-9.3
-RUN sudo -u postgres createuser -srd ubuntu
-RUN sudo -u postgres psql -c "create database ubuntu owner=ubuntu"
+RUN apt-get install -y postgresql-9.3 && \
+    sudo -u postgres createuser -srd ubuntu && \
+    sudo -u postgres psql -c "create database ubuntu owner=ubuntu"
 
 # tools
 RUN apt-get install -y dnsutils bash-completion xsltproc \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -80,8 +80,12 @@ RUN apt-get install -y xvfb tightvncserver x11vnc novnc xterm fluxbox
 RUN apt-get install -y firefox chromium-browser
 
 # servers
-RUN apt-get install -y redis-server redis-tools nginx postgresql-9.3
+RUN apt-get install -y redis-server redis-tools nginx
 RUN apt-get install -y mysql-server rabbitmq-server couchdb
+
+# Postgres
+RUN apt-get install -y postgresql-9.3
+RUN sudo -u postgres createuser -sd ubuntu
 
 # tools
 RUN apt-get install -y dnsutils bash-completion xsltproc \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -85,7 +85,8 @@ RUN apt-get install -y mysql-server rabbitmq-server couchdb
 
 # Postgres
 RUN apt-get install -y postgresql-9.3
-RUN sudo -u postgres createuser -sd ubuntu
+RUN sudo -u postgres createuser -srd ubuntu
+RUN sudo -u postgres psql -c "create database ubuntu owner=ubuntu"
 
 # tools
 RUN apt-get install -y dnsutils bash-completion xsltproc \


### PR DESCRIPTION
@fjakobs @timjrobinson @abailiss 

Just set up an ubuntu account and database in postgres so users can run `psql` straight away as the ubuntu user without having to screw around with `sudo`