### PR TITLE
Fix container should start as root

### DIFF
--- a/ws-ruby/Dockerfile
+++ b/ws-ruby/Dockerfile
@@ -27,3 +27,5 @@ RUN bash -l -c "rvm install ruby-2.3.0 && \
     NOKOGIRI_USE_SYSTEM_LIBRARIES=1 gem install rails -v 5.0.0.beta3"
 
 RUN bash -l -c "rails new /home/ubuntu/workspace"
+
+USER root


### PR DESCRIPTION
- Container entrypoint must run as root or `nsenter` fails

@timjrobinson @fjakobs 