### PR TITLE
Show project name in the prompt

### DIFF
--- a/workspace/files/home/ubuntu/.bashrc
+++ b/workspace/files/home/ubuntu/.bashrc
@@ -41,7 +41,7 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
     . /etc/bash_completion
 fi
 
-PS1='\[\033[01;32m\]${C9_USER}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(__git_ps1 " (%s)") $ '
+PS1='\[\033[01;32m\]${C9_USER}/${C9_PROJECT}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(__git_ps1 " (%s)") $ '
 
 # If this is an xterm set the title to user@host:dir
 case "$TERM" in

--- a/workspace/files/home/ubuntu/.bashrc
+++ b/workspace/files/home/ubuntu/.bashrc
@@ -41,7 +41,7 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
     . /etc/bash_completion
 fi
 
-PS1='\[\033[01;32m\]${C9_USER}/${C9_PROJECT}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(__git_ps1 " (%s)") $ '
+PS1='\[\033[01;32m\]${C9_USER}/${C9_PROJECT::16}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(__git_ps1 " (%s)") $ '
 
 # If this is an xterm set the title to user@host:dir
 case "$TERM" in


### PR DESCRIPTION
Running many workspaces, the terminal prompt is the place I look at often and where I can easily read the projectname.