### PR TITLE
Remove mongod alias

### DIFF
--- a/workspace/files/home/ubuntu/.bash_aliases
+++ b/workspace/files/home/ubuntu/.bash_aliases
@@ -9,5 +9,4 @@ alias less="less -R "
 
 alias mysqldump="mysqldump --user=$C9_USER --host=$IP"
 alias php="php -c ~/workspace/php.ini"
-alias mongod="mongod --bind_ip=$IP --small --rest '$@'"
 alias ..="cd .."


### PR DESCRIPTION
This alias is unexpected by users new to c9 and causes errors when unaware of the alias.