### PR TITLE
Remove .app from global gitignore since it is used by salesforce

### DIFF
--- a/workspace/files/gitignore
+++ b/workspace/files/gitignore
@@ -18,7 +18,6 @@ Thumbs.db
 *.dll
 *.exe
 *.out
-*.app
 install_manifest.txt
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
@justin8 @fjakobs 