### PR TITLE
Upgrade to latest LTS for Ubuntu

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM ubuntu:16.04
 MAINTAINER Cloud9 IDE, inc. <info@c9.io>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Trusty is nearing EOL. Use Xenial Xerus instead.