### PR TITLE
Go 1.8

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -108,7 +108,7 @@ RUN wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh -e
 RUN sudo -u ubuntu -i heroku --help
 
 # /opt packages
-RUN curl https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar -C /opt -xz
+RUN curl https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -C /opt -xz
 RUN git clone https://github.com/lennartcl/gitl.git /opt/gitl
 
 # setup the system


### PR DESCRIPTION
Go 1.8 has been released in February.

- https://blog.golang.org/go1.8
- https://golang.org/doc/devel/release.html
- https://golang.org/doc/go1.8