### PR TITLE
dont check version of the default python for now

### DIFF
--- a/workspace/files/check-environment
+++ b/workspace/files/check-environment
@@ -46,7 +46,8 @@ mvn --version
 
 ruby --version | grep 2\..\..
 
-python --version 2>&1 | grep 'Python 2'
+python --version 2>&1 | grep 'Python'
+python2 --version 2>&1 | grep 'Python 2'
 python3 --version 2>&1 | grep 'Python 3'
 pip --version
 


### PR DESCRIPTION
* Check for python 2 and 3 explicity
* Ignore the version for the default python (fix for cs50)